### PR TITLE
Fix bugs and improve pkg/grpc/auth package

### DIFF
--- a/pkg/grpc/auth/auth.go
+++ b/pkg/grpc/auth/auth.go
@@ -113,7 +113,7 @@ func (api *API) AuthorizeIds(ctx context.Context, ids ...string) (*Payload, erro
 		}
 	}
 
-	return nil, status.Errorf(codes.PermissionDenied, "permission denied for actors ids [%s]", strings.Join(ids, ", "))
+	return nil, status.Errorf(codes.PermissionDenied, "permission denied: actor id %s is not in allowed list [%s]", claims.ID, strings.Join(ids, ", "))
 }
 
 // AddAdminGroups adds admin groups
@@ -232,35 +232,15 @@ func (api *API) GetMetadataFromCtx(ctx context.Context) metadata.MD {
 // If error is returned, its grpc.Code() will be returned to the user as well as the verbatim message.
 // Please make sure you use codes.Unauthenticated (lacking auth) and codes.PermissionDenied
 func (api *API) Authenticator(ctx context.Context) (context.Context, error) {
-	token, err := grpc_auth.AuthFromMD(ctx, "bearer")
-	if err != nil {
-		return nil, err
-	}
-
-	claims, err := api.parseToken(token, api.signingKey)
-	if err != nil {
-		fmt.Println(err)
-		return nil, status.Errorf(codes.Unauthenticated, "session expired")
-	}
-
-	// Fetch additional payload data if a provider is configured and ID is present
-	if api.payloadProvider != nil && claims.ID != "" {
-		if fullPayload, err := api.payloadProvider.GetPayload(ctx, claims.ID); err == nil && fullPayload != nil {
-			claims.Payload.Names = fullPayload.Names
-			claims.Payload.PhoneNumber = fullPayload.PhoneNumber
-			claims.Payload.EmailAddress = fullPayload.EmailAddress
-			claims.Payload.Group = fullPayload.Group
-			claims.Payload.Roles = fullPayload.Roles
-		}
-	}
-
-	grpc_ctxtags.Extract(ctx).Set("auth.sub", userClaimFromToken(claims))
-
-	return context.WithValue(ctx, claimsKey, claims), nil
+	return api.authenticate(ctx, api.signingKey)
 }
 
 // AuthenticatorWithKey works like Authenticator but allow users to pass in custome key for decoding jwt data
 func (api *API) AuthenticatorWithKey(ctx context.Context, signingKey []byte) (context.Context, error) {
+	return api.authenticate(ctx, signingKey)
+}
+
+func (api *API) authenticate(ctx context.Context, signingKey []byte) (context.Context, error) {
 	token, err := grpc_auth.AuthFromMD(ctx, "bearer")
 	if err != nil {
 		return nil, err
@@ -272,7 +252,7 @@ func (api *API) AuthenticatorWithKey(ctx context.Context, signingKey []byte) (co
 	}
 
 	// Fetch additional payload data if a provider is configured and ID is present
-	if api.payloadProvider != nil && claims.ID != "" {
+	if api.payloadProvider != nil && claims.Payload != nil && claims.ID != "" {
 		if fullPayload, err := api.payloadProvider.GetPayload(ctx, claims.ID); err == nil && fullPayload != nil {
 			claims.Payload.Names = fullPayload.Names
 			claims.Payload.PhoneNumber = fullPayload.PhoneNumber
@@ -302,7 +282,7 @@ func (api *API) parseToken(tokenString string, signingKey []byte) (claims *Claim
 
 	token, err := jwt.ParseWithClaims(
 		tokenString,
-		&Claims{},
+		&Claims{Payload: &Payload{}},
 		func(token *jwt.Token) (interface{}, error) {
 			return signingKey, nil
 		},
@@ -328,7 +308,7 @@ func matchGroup(claimGroup string, groups []string) error {
 			return nil
 		}
 	}
-	return status.Errorf(codes.PermissionDenied, "permission denied for group %s", claimGroup)
+	return status.Errorf(codes.PermissionDenied, "permission denied: group %s is not in allowed list [%s]", claimGroup, strings.Join(groups, ", "))
 }
 
 func matchGroups(claimGroups []string, groups []string) error {
@@ -339,5 +319,5 @@ func matchGroups(claimGroups []string, groups []string) error {
 			}
 		}
 	}
-	return status.Errorf(codes.PermissionDenied, "permission denied for groups %s", strings.Join(claimGroups, ","))
+	return status.Errorf(codes.PermissionDenied, "permission denied: none of the groups [%s] are in allowed list [%s]", strings.Join(claimGroups, ", "), strings.Join(groups, ", "))
 }

--- a/pkg/grpc/auth/auth_test.go
+++ b/pkg/grpc/auth/auth_test.go
@@ -1,0 +1,255 @@
+package grpcauth
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+)
+
+func TestGenTokenV2(t *testing.T) {
+	api := NewAPI([]byte("secret"), "issuer", "audience")
+	payload := &Payload{
+		ID:        "user-1",
+		ProjectID: "project-1",
+	}
+	claims := &Claims{
+		Payload: payload,
+		StandardClaims: jwt.StandardClaims{
+			ExpiresAt: time.Now().Add(time.Hour).Unix(),
+		},
+	}
+
+	// This is what GenTokenFromClaims does
+	expires := time.Now().Add(2 * time.Hour).Unix()
+	tokenStr, err := api.genTokenV2(context.Background(), claims, expires, api.signingKey)
+	if err != nil {
+		t.Fatalf("failed to gen token: %v", err)
+	}
+
+	parsedClaims, err := api.parseToken(tokenStr, api.signingKey)
+	if err != nil {
+		t.Fatalf("failed to parse token: %v", err)
+	}
+
+	if parsedClaims.ExpiresAt != expires {
+		t.Errorf("expected ExpiresAt %d, got %d", expires, parsedClaims.ExpiresAt)
+	}
+}
+
+func TestAuthenticator_NilPayload(t *testing.T) {
+	api := NewAPI([]byte("secret"), "issuer", "audience")
+
+	// Create a token with NO payload fields
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.StandardClaims{
+		Subject: "test",
+	})
+	tokenStr, _ := token.SignedString([]byte("secret"))
+
+	claims, err := api.parseToken(tokenStr, []byte("secret"))
+	if err != nil {
+		t.Fatalf("Parse token failed: %v", err)
+	}
+
+	if claims.Payload == nil {
+		t.Error("claims.Payload is nil, expected pre-allocated Payload")
+	}
+
+	// This should NOT panic
+	_ = claims.ID
+}
+
+func TestAuthorizeGroups(t *testing.T) {
+	api := NewAPI([]byte("secret"), "issuer", "audience")
+
+	tests := []struct {
+		name          string
+		claims        *Claims
+		allowedGroups []string
+		wantErr       bool
+		errCode       codes.Code
+	}{
+		{
+			name: "Authorized via Group",
+			claims: &Claims{
+				Payload: &Payload{Group: "ADMIN"},
+			},
+			allowedGroups: []string{"ADMIN", "USER"},
+			wantErr:       false,
+		},
+		{
+			name: "Authorized via Roles",
+			claims: &Claims{
+				Payload: &Payload{Group: "GUEST", Roles: []string{"ADMIN"}},
+			},
+			allowedGroups: []string{"ADMIN"},
+			wantErr:       false,
+		},
+		{
+			name: "Unauthorized",
+			claims: &Claims{
+				Payload: &Payload{Group: "GUEST", Roles: []string{"USER"}},
+			},
+			allowedGroups: []string{"ADMIN"},
+			wantErr:       true,
+			errCode:       codes.PermissionDenied,
+		},
+		{
+			name:          "No claims",
+			claims:        nil,
+			allowedGroups: []string{"ADMIN"},
+			wantErr:       true,
+			errCode:       codes.Unauthenticated,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			if tt.claims != nil {
+				ctx = context.WithValue(ctx, claimsKey, tt.claims)
+			}
+
+			payload, err := api.AuthorizeGroups(ctx, tt.allowedGroups...)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("AuthorizeGroups() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if tt.wantErr {
+				if status.Code(err) != tt.errCode {
+					t.Errorf("AuthorizeGroups() error code = %v, want %v", status.Code(err), tt.errCode)
+				}
+				if tt.errCode == codes.PermissionDenied && !strings.Contains(err.Error(), "allowed list") {
+					t.Errorf("AuthorizeGroups() error message should contain 'allowed list', got: %v", err)
+				}
+			} else if payload == nil {
+				t.Error("AuthorizeGroups() returned nil payload on success")
+			}
+		})
+	}
+}
+
+func TestAuthorizeIds(t *testing.T) {
+	api := NewAPI([]byte("secret"), "issuer", "audience")
+
+	tests := []struct {
+		name       string
+		claims     *Claims
+		allowedIds []string
+		wantErr    bool
+		errCode    codes.Code
+	}{
+		{
+			name: "Authorized",
+			claims: &Claims{
+				Payload: &Payload{ID: "user-1"},
+			},
+			allowedIds: []string{"user-1", "user-2"},
+			wantErr:    false,
+		},
+		{
+			name: "Unauthorized",
+			claims: &Claims{
+				Payload: &Payload{ID: "user-3"},
+			},
+			allowedIds: []string{"user-1", "user-2"},
+			wantErr:    true,
+			errCode:    codes.PermissionDenied,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.WithValue(context.Background(), claimsKey, tt.claims)
+
+			payload, err := api.AuthorizeIds(ctx, tt.allowedIds...)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("AuthorizeIds() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if tt.wantErr {
+				if status.Code(err) != tt.errCode {
+					t.Errorf("AuthorizeIds() error code = %v, want %v", status.Code(err), tt.errCode)
+				}
+				if tt.errCode == codes.PermissionDenied && !strings.Contains(err.Error(), "allowed list") {
+					t.Errorf("AuthorizeIds() error message should contain 'allowed list', got: %v", err)
+				}
+			} else if payload == nil {
+				t.Error("AuthorizeIds() returned nil payload on success")
+			}
+		})
+	}
+}
+
+type mockPayloadProvider struct {
+	getPayloadFunc func(ctx context.Context, id string) (*Payload, error)
+}
+
+func (m *mockPayloadProvider) GetPayload(ctx context.Context, id string) (*Payload, error) {
+	return m.getPayloadFunc(ctx, id)
+}
+
+func TestAuthenticator(t *testing.T) {
+	api := NewAPI([]byte("secret"), "issuer", "audience")
+
+	t.Run("Valid Token", func(t *testing.T) {
+		tokenStr, _ := api.GenToken(context.Background(), &Payload{ID: "user-1"}, time.Now().Add(time.Hour))
+		md := metadata.Pairs("authorization", "Bearer "+tokenStr)
+		ctx := metadata.NewIncomingContext(context.Background(), md)
+
+		newCtx, err := api.Authenticator(ctx)
+		if err != nil {
+			t.Fatalf("Authenticator() error = %v", err)
+		}
+
+		claims, err := api.GetClaims(newCtx)
+		if err != nil {
+			t.Fatalf("GetClaims() error = %v", err)
+		}
+		if claims.ID != "user-1" {
+			t.Errorf("expected ID user-1, got %s", claims.ID)
+		}
+	})
+
+	t.Run("Expired Token", func(t *testing.T) {
+		tokenStr, _ := api.genToken(context.Background(), &Payload{ID: "user-1"}, time.Now().Add(-time.Hour).Unix())
+		md := metadata.Pairs("authorization", "Bearer "+tokenStr)
+		ctx := metadata.NewIncomingContext(context.Background(), md)
+
+		_, err := api.Authenticator(ctx)
+		if err == nil {
+			t.Fatal("Authenticator() expected error for expired token, got nil")
+		}
+		if status.Code(err) != codes.Unauthenticated {
+			t.Errorf("expected Unauthenticated, got %v", status.Code(err))
+		}
+	})
+
+	t.Run("With PayloadProvider", func(t *testing.T) {
+		api.SetPayloadProvider(&mockPayloadProvider{
+			getPayloadFunc: func(ctx context.Context, id string) (*Payload, error) {
+				return &Payload{ID: id, Group: "DYNAMIC_GROUP"}, nil
+			},
+		})
+		defer api.SetPayloadProvider(nil)
+
+		tokenStr, _ := api.GenToken(context.Background(), &Payload{ID: "user-2"}, time.Now().Add(time.Hour))
+		md := metadata.Pairs("authorization", "Bearer "+tokenStr)
+		ctx := metadata.NewIncomingContext(context.Background(), md)
+
+		newCtx, err := api.Authenticator(ctx)
+		if err != nil {
+			t.Fatalf("Authenticator() error = %v", err)
+		}
+
+		claims, _ := api.GetClaims(newCtx)
+		if claims.Group != "DYNAMIC_GROUP" {
+			t.Errorf("expected Group DYNAMIC_GROUP, got %s", claims.Group)
+		}
+	})
+}

--- a/pkg/grpc/auth/jwt.go
+++ b/pkg/grpc/auth/jwt.go
@@ -56,7 +56,8 @@ func (api *API) genTokenV2(_ context.Context, claims *Claims, expires int64, sig
 		}
 	}()
 
-	token := jwt.NewWithClaims(api.signingMethod, *claims)
+	claims.ExpiresAt = expires
+	token := jwt.NewWithClaims(api.signingMethod, claims)
 
 	token.Header["kid"] = claims.ProjectID
 


### PR DESCRIPTION
I have reviewed the `pkg/grpc/auth` package and implemented several fixes and improvements:

1.  **Bug Fixes**:
    *   Fixed `genTokenV2` in `jwt.go` to correctly set the `ExpiresAt` field from the provided `expires` parameter.
    *   Harden `parseToken` in `auth.go` to pre-allocate the `Payload` pointer, preventing nil pointer dereferences when a token lacks payload data.
2.  **Refactoring**:
    *   Extracted shared authentication logic into a private `authenticate` method to reduce code duplication between `Authenticator` and `AuthenticatorWithKey`.
3.  **Improved Error Messages**:
    *   Updated `AuthorizeGroups`, `AuthorizeIds`, and related helpers to return more informative error messages that include both the provided and the allowed values, aiding in debugging.
4.  **Testing**:
    *   Added `pkg/grpc/auth/auth_test.go` with comprehensive test coverage for token generation, parsing, authentication middleware, and authorization checks.

All tests pass, and the package is more robust and maintainable. I recommend tagging the next release as `v1.0.1`.

---
*PR created automatically by Jules for task [7307758900144848415](https://jules.google.com/task/7307758900144848415) started by @gidyon*